### PR TITLE
ONCEHUB-118574   Added a default tel type to Phone Interaction in Oncehub ui React 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oncehub/ui-react",
-  "version": "2.1.7",
+  "version": "2.1.7-beta-0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oncehub/ui-react",
-      "version": "2.1.7",
+      "version": "2.1.7-beta-0",
       "devDependencies": {
         "@babel/core": "^7.23.2",
         "@eslint/js": "^9.39.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oncehub/ui-react",
-  "version": "2.1.9-beta-0",
+  "version": "2.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oncehub/ui-react",
-      "version": "2.1.9-beta-0",
+      "version": "2.1.9",
       "devDependencies": {
         "@babel/core": "^7.23.2",
         "@eslint/js": "^9.39.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oncehub/ui-react",
-  "version": "2.1.7-beta-0",
+  "version": "2.1.9-beta-0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oncehub/ui-react",
-      "version": "2.1.7-beta-0",
+      "version": "2.1.9-beta-0",
       "devDependencies": {
         "@babel/core": "^7.23.2",
         "@eslint/js": "^9.39.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oncehub/ui-react",
   "private": false,
-  "version": "2.1.9-beta-0",
+  "version": "2.1.9",
   "type": "module",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oncehub/ui-react",
   "private": false,
-  "version": "2.1.8",
+  "version": "2.1.7-beta-0",
   "type": "module",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oncehub/ui-react",
   "private": false,
-  "version": "2.1.7-beta-0",
+  "version": "2.1.9-beta-0",
   "type": "module",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oncehub/ui-react",
   "private": false,
-  "version": "2.1.7",
+  "version": "2.1.8",
   "type": "module",
   "repository": {
     "type": "git",

--- a/src/lib/components/phone/phone.tsx
+++ b/src/lib/components/phone/phone.tsx
@@ -2,7 +2,7 @@ import { SelectOption, SelectOptions } from '../select/select-options';
 import { Select } from '../select/select';
 import { SingleLineInput } from '../single-line-input';
 import { IOption } from '../../interfaces/select.type';
-import { FC, useEffect, useRef, useState } from 'react';
+import React, { FC, useEffect, useRef, useState } from 'react';
 import styles from './phone.module.scss';
 import { isValidPhoneNumber, getCountries, getCountryCallingCode } from 'react-phone-number-input/max';
 import { CountryCode } from 'libphonenumber-js';
@@ -21,6 +21,8 @@ interface Props {
   phoneNumberValue?: string | null;
   countryCodeFromURL?: string | null;
   additionalClassName?: string;
+  type?: string;
+  inputMode?: React.HTMLAttributes<HTMLInputElement>['inputMode'];
 }
 
 export const Phone: FC<Props> = ({
@@ -35,6 +37,8 @@ export const Phone: FC<Props> = ({
   phoneNumberValue = '',
   countryCodeFromURL = '',
   additionalClassName = '',
+  type = 'tel',
+  inputMode = 'numeric',
 }) => {
   /* Country Dropdown */
   const [validationError, setValidationError] = useState<boolean>(error);
@@ -184,7 +188,8 @@ export const Phone: FC<Props> = ({
           </div>
           <div className={`${styles.phoneInputWrap} ouiPhoneInputWrap`}>
             <SingleLineInput
-              type="text"
+              type={type}
+              inputMode={inputMode}
               aria-labelledby="phone-number"
               placeholder={placeholder}
               className={`${styles.phoneInput} ${validationError && validate ? styles.serverError : ''} ouiPhoneInput`}


### PR DESCRIPTION
https://scheduleonce.atlassian.net/browse/ONCEHUB-118574

This pull request introduces enhancements to the `Phone` component in the UI library, focusing on improving input flexibility and accessibility. The most significant changes allow consumers of the `Phone` component to specify the input `type` and `inputMode`, making the component more adaptable to various use cases. Additionally, there are minor dependency and import updates.

Enhancements to the `Phone` component:

* Added optional `type` and `inputMode` props to the `Phone` component interface, allowing callers to specify the input type (default `'tel'`) and input mode (default `'numeric'`).
* Updated the `Phone` component to use the new `type` and `inputMode` props in the underlying `SingleLineInput`, replacing the hardcoded `"text"` type. [[1]](diffhunk://#diff-6382188b4b91119567c250cd92402b981af69a8208b9ba26f3660a8f689ab09dR40-R41) [[2]](diffhunk://#diff-6382188b4b91119567c250cd92402b981af69a8208b9ba26f3660a8f689ab09dL187-R192)

Codebase and dependency updates:

* Updated the import statement in `phone.tsx` to use the `React` namespace, ensuring compatibility with JSX and future React versions.
* Bumped the package version in `package.json` from `2.1.7` to `2.1.9` to reflect these enhancements.